### PR TITLE
Resolve issues staging up with `--prune`

### DIFF
--- a/lib/ninny/git.rb
+++ b/lib/ninny/git.rb
@@ -38,7 +38,7 @@ module Ninny
 
     def merge(branch_name)
       if_clean do
-        `git fetch --prune`
+        `git fetch --prune &> /dev/null`
         command 'merge', ['--no-ff', "origin/#{branch_name}"]
         raise MergeFailed unless clean?
 
@@ -65,7 +65,7 @@ module Ninny
     # branch_name - The name of the branch to check out
     # do_after_pull - Should a pull be done after checkout?
     def check_out(branch, do_after_pull = true)
-      `git fetch --prune`
+      `git fetch --prune &> /dev/null`
       git.checkout(branch)
       pull if do_after_pull
       raise CheckoutFailed, "Failed to check out '#{branch}'" unless current_branch.name == branch.name
@@ -84,7 +84,7 @@ module Ninny
     # new_branch_name - The name of the branch to create
     # source_branch_name - The name of the branch to branch from
     def new_branch(new_branch_name, source_branch_name)
-      `git fetch --prune`
+      `git fetch --prune &> /dev/null`
       remote_branches = command('branch', ['--remote'])
 
       if remote_branches.include?("origin/#{new_branch_name}")
@@ -117,7 +117,7 @@ module Ninny
     #
     # Returns an Array of Strings containing the branch names
     def remote_branches
-      `git fetch --prune`
+      `git fetch --prune &> /dev/null`
       git.branches.remote.map { |branch| git.branch(branch.name) }.sort_by(&:name)
     end
 

--- a/lib/ninny/git.rb
+++ b/lib/ninny/git.rb
@@ -38,7 +38,7 @@ module Ninny
 
     def merge(branch_name)
       if_clean do
-        git.fetch('-p')
+        `git fetch --prune`
         command 'merge', ['--no-ff', "origin/#{branch_name}"]
         raise MergeFailed unless clean?
 
@@ -65,7 +65,7 @@ module Ninny
     # branch_name - The name of the branch to check out
     # do_after_pull - Should a pull be done after checkout?
     def check_out(branch, do_after_pull = true)
-      git.fetch('-p')
+      `git fetch --prune`
       git.checkout(branch)
       pull if do_after_pull
       raise CheckoutFailed, "Failed to check out '#{branch}'" unless current_branch.name == branch.name
@@ -84,7 +84,7 @@ module Ninny
     # new_branch_name - The name of the branch to create
     # source_branch_name - The name of the branch to branch from
     def new_branch(new_branch_name, source_branch_name)
-      git.fetch('-p')
+      `git fetch --prune`
       remote_branches = command('branch', ['--remote'])
 
       if remote_branches.include?("origin/#{new_branch_name}")
@@ -117,7 +117,7 @@ module Ninny
     #
     # Returns an Array of Strings containing the branch names
     def remote_branches
-      git.fetch('-p')
+      `git fetch --prune`
       git.branches.remote.map { |branch| git.branch(branch.name) }.sort_by(&:name)
     end
 

--- a/lib/ninny/version.rb
+++ b/lib/ninny/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ninny
-  VERSION = '0.1.21'
+  VERSION = '0.1.22'
 end

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Ninny::Git do
 
   context '#merge' do
     it 'should fetch and merge branch_name' do
-      expect(subject).to receive(:`).with('git fetch --prune')
+      expect(subject).to receive(:`).with('git fetch --prune &> /dev/null')
       expect(git_lib).to receive(:command).with('merge', ['--no-ff', 'origin/branch_to_merge'])
       expect(subject).to receive(:push)
       subject.merge('branch_to_merge')
@@ -45,7 +45,7 @@ RSpec.describe Ninny::Git do
       it 'should fetch, create a new branch, checkout and push the new branch' do
         new_branch = double(:new_branch)
         expect(new_branch).to receive(:checkout)
-        expect(subject).to receive(:`).with('git fetch --prune')
+        expect(subject).to receive(:`).with('git fetch --prune &> /dev/null')
         expect(subject).to receive(:command).with('branch', ['--remote']).and_return('')
         expect(subject).to receive(:command).with('branch', ['--no-track', 'new_branch', 'origin/main'])
         expect(subject).to receive(:branch).with('new_branch').and_return(new_branch)
@@ -56,7 +56,7 @@ RSpec.describe Ninny::Git do
       it 'should catch errors that happen when creating' do
         new_branch = double(:new_branch)
         expect(new_branch).to receive(:checkout)
-        expect(subject).to receive(:`).with('git fetch --prune')
+        expect(subject).to receive(:`).with('git fetch --prune &> /dev/null')
         expect(subject).to receive(:command).with('branch', ['--remote']).and_return('')
         expect(subject).to receive(:command).with('branch', ['--no-track', 'new_branch', 'origin/main'])
         expect(subject).to receive(:branch).with('new_branch').and_return(new_branch)
@@ -69,7 +69,7 @@ RSpec.describe Ninny::Git do
 
     context 'if the remote branch already exists' do
       it 'should ask the user if they would like to recreate the existing branch' do
-        expect(subject).to receive(:`).with('git fetch --prune')
+        expect(subject).to receive(:`).with('git fetch --prune &> /dev/null')
         expect(subject).to receive(:command).with('branch', ['--remote']).and_return('origin/new_branch')
         allow(subject).to receive(:exit)
         expect(subject).to receive(:prompt).and_return(double(yes?: false))
@@ -79,7 +79,7 @@ RSpec.describe Ninny::Git do
       it 'should correctly call to delete the branch if the user says yes to recreation' do
         new_branch = double(:new_branch)
         expect(new_branch).to receive(:checkout)
-        expect(subject).to receive(:`).with('git fetch --prune').at_least(:twice)
+        expect(subject).to receive(:`).with('git fetch --prune &> /dev/null').at_least(:twice)
         expect(subject).to receive(:command).with('branch', ['--remote']).and_return('origin/new_branch', '')
         expect(subject).to receive(:command).with('branch', ['--no-track', 'new_branch', 'origin/main'])
         expect(subject).to receive(:branch).with('new_branch').and_return(new_branch)
@@ -90,7 +90,7 @@ RSpec.describe Ninny::Git do
       end
 
       it 'should exit if the user says no to recreation' do
-        expect(subject).to receive(:`).with('git fetch --prune')
+        expect(subject).to receive(:`).with('git fetch --prune &> /dev/null')
         expect(subject).to receive(:command).with('branch', ['--remote']).and_return('origin/new_branch')
         expect(subject).to receive(:exit)
         expect(subject).to receive(:prompt).and_return(double(yes?: false))

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Ninny::Git do
 
   context '#merge' do
     it 'should fetch and merge branch_name' do
-      expect(subject.git).to receive(:fetch)
+      expect(subject).to receive(:`).with('git fetch --prune')
       expect(git_lib).to receive(:command).with('merge', ['--no-ff', 'origin/branch_to_merge'])
       expect(subject).to receive(:push)
       subject.merge('branch_to_merge')
@@ -45,7 +45,7 @@ RSpec.describe Ninny::Git do
       it 'should fetch, create a new branch, checkout and push the new branch' do
         new_branch = double(:new_branch)
         expect(new_branch).to receive(:checkout)
-        expect(subject.git).to receive(:fetch)
+        expect(subject).to receive(:`).with('git fetch --prune')
         expect(subject).to receive(:command).with('branch', ['--remote']).and_return('')
         expect(subject).to receive(:command).with('branch', ['--no-track', 'new_branch', 'origin/main'])
         expect(subject).to receive(:branch).with('new_branch').and_return(new_branch)
@@ -56,7 +56,7 @@ RSpec.describe Ninny::Git do
       it 'should catch errors that happen when creating' do
         new_branch = double(:new_branch)
         expect(new_branch).to receive(:checkout)
-        expect(subject.git).to receive(:fetch)
+        expect(subject).to receive(:`).with('git fetch --prune')
         expect(subject).to receive(:command).with('branch', ['--remote']).and_return('')
         expect(subject).to receive(:command).with('branch', ['--no-track', 'new_branch', 'origin/main'])
         expect(subject).to receive(:branch).with('new_branch').and_return(new_branch)
@@ -69,7 +69,7 @@ RSpec.describe Ninny::Git do
 
     context 'if the remote branch already exists' do
       it 'should ask the user if they would like to recreate the existing branch' do
-        expect(subject.git).to receive(:fetch)
+        expect(subject).to receive(:`).with('git fetch --prune')
         expect(subject).to receive(:command).with('branch', ['--remote']).and_return('origin/new_branch')
         allow(subject).to receive(:exit)
         expect(subject).to receive(:prompt).and_return(double(yes?: false))
@@ -79,7 +79,7 @@ RSpec.describe Ninny::Git do
       it 'should correctly call to delete the branch if the user says yes to recreation' do
         new_branch = double(:new_branch)
         expect(new_branch).to receive(:checkout)
-        expect(subject.git).to receive(:fetch).at_least(:twice)
+        expect(subject).to receive(:`).with('git fetch --prune').at_least(:twice)
         expect(subject).to receive(:command).with('branch', ['--remote']).and_return('origin/new_branch', '')
         expect(subject).to receive(:command).with('branch', ['--no-track', 'new_branch', 'origin/main'])
         expect(subject).to receive(:branch).with('new_branch').and_return(new_branch)
@@ -90,7 +90,7 @@ RSpec.describe Ninny::Git do
       end
 
       it 'should exit if the user says no to recreation' do
-        expect(subject.git).to receive(:fetch)
+        expect(subject).to receive(:`).with('git fetch --prune')
         expect(subject).to receive(:command).with('branch', ['--remote']).and_return('origin/new_branch')
         expect(subject).to receive(:exit)
         expect(subject).to receive(:prompt).and_return(double(yes?: false))


### PR DESCRIPTION
<!--
Your audience for this merge request description is **code reviewers**. Help them understand the technical implications involved in this change. The JIRA ticket should outline the user-facing details.

Remember that Product and QA teams may have other test cases, verifications, and requirements associated with this change. Your Verification and QA plan should be directed towards Code Reviewers.
-->

## What and Why

<!--
What are you changing? Describe impact and scope. Why is this being changed? Provide some context that may help future developers understand the reasoning behind these changes. Quote and/or link to requirements, keeping in mind that JIRA links may not be available in the future.
-->

After updating to `git` version `2.36.0` with Ruby version `3.1.2`, I started seeing this error:
```
$ ninny stage_up
/Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/git-1.11.0/lib/git/lib.rb:1118:in `command': git '--git-dir=/Users/emmasax/projects/TEST-PROJECT/.git' '--work-tree=/Users/emmasax/projects/TEST-PROJECT' '-c' 'core.quotePath=true' '-c' 'color.ui=false' fetch '--' '-p'  2>&1:fatal: strange pathname '-p' blocked (Git::GitExecuteError)
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/git-1.11.0/lib/git/lib.rb:890:in `fetch'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/git-1.11.0/lib/git/base.rb:340:in `fetch'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/ninny-0.1.21/lib/ninny/git.rb:120:in `remote_branches'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/ninny-0.1.21/lib/ninny/git.rb:130:in `branches_for'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/ninny-0.1.21/lib/ninny/git.rb:141:in `latest_branch_for'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/ninny-0.1.21/lib/ninny/commands/pull_request_merge.rb:87:in `branch_to_merge_into'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/ninny-0.1.21/lib/ninny/commands/pull_request_merge.rb:45:in `check_out_branch'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/ninny-0.1.21/lib/ninny/commands/pull_request_merge.rb:27:in `execute'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/ninny-0.1.21/lib/ninny/cli.rb:41:in `stage_up'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
        from /Users/emmasax/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/ninny-0.1.21/exe/ninny:15:in `<top (required)>'
        from /Users/emmasax/.rbenv/versions/3.1.2/bin/ninny:25:in `load'
        from /Users/emmasax/.rbenv/versions/3.1.2/bin/ninny:25:in `<main>'
```

Unfortunately, Googling gave me nothing. My guess this is related to the newer version of `git`, or the newer version of Ruby... or both.

Expanding `-p` to `--prune` resulted in this:
```diff
- git.fetch('-p')
+ git.fetch('--prune')
# =====>>>>
#   2>&1:fatal: strange pathname '--prune' blocked (Git::GitExecuteError)
``` 

And getting rid of the prune entirely worked:
```diff
- git.fetch('-p')
+ git.fetch
# =====>>>>
#   SUCCESS!
```

But we want the prune, so instead I opted to just replace it with raw backticks:
```diff
- git.fetch('-p')
+ `git fetch --prune`
# =====>>>>
#   SUCCESS!
```

It's not a perfect solution, but it'll fix up the bug.

## Deploy Plan

<!--
Is there anything special about this deploy? Are migrations present? Are there other merge requests that need to be shipped before this one? Are there any manual steps required, such as data migrations, search reindexes, etc?
-->

Make a new release and tag!

## Rollback Plan

<!--
Is there anything special about this rollback plan? Does this merge request anything that may need to be cleaned up manually (data migrations, search reindexes, etc)? Are there other associated merge requests that would also need to be reverted?
-->

To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

## Related URLs

<!--
Links to bug tickets, user stories, or other merge requests.
-->

## Verification and QA Plan

<!--
Fill in scenarios below in checklist format and complete them before merging. Evaluate the risk level and label this merge request or indicate risk in this description. Ensure the Verification and QA Plan matches the risk level appropriately.

Consider these topics:
* regressions (did we break something else related to this change?)
* edge cases (weird scenarios we don't immediately think of, but could occur)
* happy path (testing the new feature directly)
* data model changes
  * data elements to add or remove from indexes
  * changes in data models requiring migrations to be performed
-->

- [x] All workflows pass on this PR
- [x] Running all `ninny` commands work
