### PR TITLE
Add a nice message and a nice break if there is no staging branch to merge into

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,21 @@ env:
   GITLEAKS_VERSION: v8.15.1
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.6, 2.7, 3.0, 3.1]
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec rake
   pronto:
     if: github.EVENT_NAME == 'pull_request'
     runs-on: ubuntu-latest

--- a/lib/ninny/commands/pull_request_merge.rb
+++ b/lib/ninny/commands/pull_request_merge.rb
@@ -46,7 +46,8 @@ module Ninny
         Ninny.git.check_out(branch_to_merge_into, false)
         Ninny.git.track_current_branch
       rescue Ninny::Git::NoBranchOfType
-        prompt.say "Could not find a #{branch_type} branch. Please create one or double check it exists. If it exists, please do a fresh git pull or git fetch to ensure Ninny can find it."
+        prompt.say "Could not find a #{branch_type} branch. Please create one or double check it exists. If it " \
+                   'exists, please do a fresh git pull or git fetch to ensure Ninny can find it.'
       end
 
       # Public: Merge the pull request's branch into the checked-out branch

--- a/lib/ninny/commands/pull_request_merge.rb
+++ b/lib/ninny/commands/pull_request_merge.rb
@@ -45,6 +45,8 @@ module Ninny
         prompt.say "Checking out #{branch_to_merge_into}."
         Ninny.git.check_out(branch_to_merge_into, false)
         Ninny.git.track_current_branch
+      rescue Ninny::Git::NoBranchOfType
+        prompt.say "Could not find a #{branch_type} branch. Please create one or double check it exists. If it exists, please do a fresh git pull or git fetch to ensure Ninny can find it."
       end
 
       # Public: Merge the pull request's branch into the checked-out branch

--- a/lib/ninny/git.rb
+++ b/lib/ninny/git.rb
@@ -138,7 +138,8 @@ module Ninny
     #
     # Returns an Array of Branches containing the branch name
     def latest_branch_for(prefix)
-      branches_for(prefix).last || raise(NoBranchOfType, "No #{prefix} branch")
+      # I don't really see why the first part would break, and the second would work, but you never know
+      branches_for(prefix).last || Ninny.git.branches_for(prefix).last || raise(NoBranchOfType, "No #{prefix} branch")
     end
 
     # Public: Whether the Git index is clean (has no uncommited changes)

--- a/lib/ninny/version.rb
+++ b/lib/ninny/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ninny
-  VERSION = '0.1.22.1'
+  VERSION = '0.1.23'
 end

--- a/spec/unit/new_staging_spec.rb
+++ b/spec/unit/new_staging_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Ninny::Commands::NewStaging do
         allow(subject).to receive(:should_delete_old_branches).and_return(false)
         expect(Ninny.git).to receive(:delete_branch).with(branch_one)
         expect(Ninny.git).to receive(:delete_branch).with(branch_two)
-        expect_any_instance_of(TTY::Prompt).to receive(:yes?).with(
+        expect_any_instance_of(TTY::Prompt).to receive(:no?).with(
           /Do you want to delete the old staging branch(es)?/
         ).and_return(true)
         subject.delete_old_branches

--- a/spec/unit/pull_request_merge_spec.rb
+++ b/spec/unit/pull_request_merge_spec.rb
@@ -42,7 +42,10 @@ RSpec.describe Ninny::Commands::PullRequestMerge do
 
     it 'should end if there is no branch' do
       allow(Ninny.git).to receive(:branches_for).and_return([])
-      expect_any_instance_of(TTY::Prompt).to receive(:say).with("Could not find a staging branch. Please create one or double check it exists. If it exists, please do a fresh git pull or git fetch to ensure Ninny can find it.")
+      expect_any_instance_of(TTY::Prompt).to receive(:say).with(
+        'Could not find a staging branch. Please create one or double check it exists. If it exists, ' \
+        'please do a fresh git pull or git fetch to ensure Ninny can find it.'
+      )
       subject.check_out_branch
     end
   end

--- a/spec/unit/pull_request_merge_spec.rb
+++ b/spec/unit/pull_request_merge_spec.rb
@@ -40,10 +40,9 @@ RSpec.describe Ninny::Commands::PullRequestMerge do
       subject.check_out_branch
     end
 
-    it 'should create new branch if there is not one' do
+    it 'should end if there is no branch' do
       allow(Ninny.git).to receive(:branches_for).and_return([])
-      expect_any_instance_of(TTY::Prompt).to receive(:say).with("No #{branch_type} branch available. Creating one now.")
-      expect_any_instance_of(Ninny::Commands::CreateDatedBranch).to receive(:execute)
+      expect_any_instance_of(TTY::Prompt).to receive(:say).with("Could not find a staging branch. Please create one or double check it exists. If it exists, please do a fresh git pull or git fetch to ensure Ninny can find it.")
       subject.check_out_branch
     end
   end


### PR DESCRIPTION
<!--
Your audience for this merge request description is **code reviewers**. Help them understand the technical implications involved in this change. The JIRA ticket should outline the user-facing details.

Remember that Product and QA teams may have other test cases, verifications, and requirements associated with this change. Your Verification and QA plan should be directed towards Code Reviewers.
-->

## What and Why

This PR is piggy-backing off of https://github.com/dispatchitinc/ninny/pull/39. With the changes in #39, if ninny cannot find a staging branch, then ninny will silently fail. In this PR, I am adding an explicit message that it failed. Furthermore, I'm attempting to add another (sorta) way to find a staging branch, so we'll see if that fixes things. If it doesn't... then it's possible we don't find value in fixing the code since ninny is on the unofficial chopping block.

Also, this PR is adding back the rspec tests.

<!--
What are you changing? Describe impact and scope. Why is this being changed? Provide some context that may help future developers understand the reasoning behind these changes. Quote and/or link to requirements, keeping in mind that JIRA links may not be available in the future.
-->

## Deploy Plan

<!--
Is there anything special about this deploy? Are migrations present? Are there other merge requests that need to be shipped before this one? Are there any manual steps required, such as data migrations, search reindexes, etc?
-->

## Rollback Plan

<!--
Is there anything special about this rollback plan? Does this merge request anything that may need to be cleaned up manually (data migrations, search reindexes, etc)? Are there other associated merge requests that would also need to be reverted?
-->

To roll back this change, revert the merge with: `git revert -m 1 MERGE_SHA` and perform another deploy.

## Related URLs

<!--
Links to bug tickets, user stories, or other merge requests.
-->

## Verification and QA Plan

<!--
Fill in scenarios below in checklist format and complete them before merging. Evaluate the risk level and label this merge request or indicate risk in this description. Ensure the Verification and QA Plan matches the risk level appropriately.

Consider these topics:
* regressions (did we break something else related to this change?)
* edge cases (weird scenarios we don't immediately think of, but could occur)
* happy path (testing the new feature directly)
* data model changes
  * data elements to add or remove from indexes
  * changes in data models requiring migrations to be performed
-->

- [ ] Test out staging up successfully works

Unfortunately, I've been having trouble reproducing the original issue (where ninny cannot find a staging branch) on my local machine, but it has happened multiple times to others and on our CI runners. Therefore, I think the best way to see if my change fixes it, or to see if the message outputting why it didn't work works is to just merge this change and wait and see 😞 .
