### PR TITLE
Fix calls to Git::Lib

### DIFF
--- a/lib/ninny/git.rb
+++ b/lib/ninny/git.rb
@@ -39,7 +39,7 @@ module Ninny
     def merge(branch_name)
       if_clean do
         `git fetch --prune &> /dev/null`
-        command 'merge', ['--no-ff', "origin/#{branch_name}"]
+        command('merge', '--no-ff', "origin/#{branch_name}")
         raise MergeFailed unless clean?
 
         push
@@ -75,7 +75,7 @@ module Ninny
     #
     # do_after_pull - Should a pull be done after tracking?
     def track_current_branch(do_after_pull = true)
-      command('branch', ['-u', "origin/#{current_branch_name}"])
+      command('branch', '-u', "origin/#{current_branch_name}")
       pull if do_after_pull
     end
 
@@ -85,7 +85,7 @@ module Ninny
     # source_branch_name - The name of the branch to branch from
     def new_branch(new_branch_name, source_branch_name)
       `git fetch --prune &> /dev/null`
-      remote_branches = command('branch', ['--remote'])
+      remote_branches = command('branch', '--remote')
 
       if remote_branches.include?("origin/#{new_branch_name}")
         ask_to_recreate_branch(new_branch_name, source_branch_name)
@@ -191,10 +191,10 @@ module Ninny
     # new_branch_name: the name of the branch in question
     # source_branch_name: the name of the branch the new branch is supposed to be based off of
     private def create_branch(new_branch_name, source_branch_name)
-      command('branch', ['--no-track', new_branch_name, "origin/#{source_branch_name}"])
+      command('branch', '--no-track', new_branch_name, "origin/#{source_branch_name}")
       new_branch = branch(new_branch_name)
       new_branch.checkout
-      command('push', ['-u', 'origin', new_branch_name])
+      command('push', '-u', 'origin', new_branch_name)
     end
 
     # Exceptions

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Ninny::Git do
   context '#merge' do
     it 'should fetch and merge branch_name' do
       expect(subject).to receive(:`).with('git fetch --prune &> /dev/null')
-      expect(git_lib).to receive(:command).with('merge', ['--no-ff', 'origin/branch_to_merge'])
+      expect(git_lib).to receive(:command).with('merge', '--no-ff', 'origin/branch_to_merge')
       expect(subject).to receive(:push)
       subject.merge('branch_to_merge')
     end
@@ -46,10 +46,10 @@ RSpec.describe Ninny::Git do
         new_branch = double(:new_branch)
         expect(new_branch).to receive(:checkout)
         expect(subject).to receive(:`).with('git fetch --prune &> /dev/null')
-        expect(subject).to receive(:command).with('branch', ['--remote']).and_return('')
-        expect(subject).to receive(:command).with('branch', ['--no-track', 'new_branch', 'origin/main'])
+        expect(subject).to receive(:command).with('branch', '--remote').and_return('')
+        expect(subject).to receive(:command).with('branch', '--no-track', 'new_branch', 'origin/main')
         expect(subject).to receive(:branch).with('new_branch').and_return(new_branch)
-        expect(subject).to receive(:command).with('push', ['-u', 'origin', 'new_branch'])
+        expect(subject).to receive(:command).with('push', '-u', 'origin', 'new_branch')
         subject.new_branch('new_branch', 'main')
       end
 
@@ -57,10 +57,10 @@ RSpec.describe Ninny::Git do
         new_branch = double(:new_branch)
         expect(new_branch).to receive(:checkout)
         expect(subject).to receive(:`).with('git fetch --prune &> /dev/null')
-        expect(subject).to receive(:command).with('branch', ['--remote']).and_return('')
-        expect(subject).to receive(:command).with('branch', ['--no-track', 'new_branch', 'origin/main'])
+        expect(subject).to receive(:command).with('branch', '--remote').and_return('')
+        expect(subject).to receive(:command).with('branch', '--no-track', 'new_branch', 'origin/main')
         expect(subject).to receive(:branch).with('new_branch').and_return(new_branch)
-        expect(subject).to receive(:command).with('push', ['-u', 'origin', 'new_branch']).and_raise(::Git::GitExecuteError.new(':fatal: A branch named new_branch already exists'))
+        expect(subject).to receive(:command).with('push', '-u', 'origin', 'new_branch').and_raise(::Git::GitExecuteError.new(':fatal: A branch named new_branch already exists'))
         allow(subject).to receive(:exit)
         allow(subject).to receive(:puts)
         subject.new_branch('new_branch', 'main')
@@ -70,7 +70,7 @@ RSpec.describe Ninny::Git do
     context 'if the remote branch already exists' do
       it 'should ask the user if they would like to recreate the existing branch' do
         expect(subject).to receive(:`).with('git fetch --prune &> /dev/null')
-        expect(subject).to receive(:command).with('branch', ['--remote']).and_return('origin/new_branch')
+        expect(subject).to receive(:command).with('branch', '--remote').and_return('origin/new_branch')
         allow(subject).to receive(:exit)
         expect(subject).to receive(:prompt).and_return(double(yes?: false))
         subject.new_branch('new_branch', 'main')
@@ -80,10 +80,10 @@ RSpec.describe Ninny::Git do
         new_branch = double(:new_branch)
         expect(new_branch).to receive(:checkout)
         expect(subject).to receive(:`).with('git fetch --prune &> /dev/null').at_least(:twice)
-        expect(subject).to receive(:command).with('branch', ['--remote']).and_return('origin/new_branch', '')
-        expect(subject).to receive(:command).with('branch', ['--no-track', 'new_branch', 'origin/main'])
+        expect(subject).to receive(:command).with('branch', '--remote').and_return('origin/new_branch', '')
+        expect(subject).to receive(:command).with('branch', '--no-track', 'new_branch', 'origin/main')
         expect(subject).to receive(:branch).with('new_branch').and_return(new_branch)
-        expect(subject).to receive(:command).with('push', ['-u', 'origin', 'new_branch'])
+        expect(subject).to receive(:command).with('push', '-u', 'origin', 'new_branch')
         expect(subject).to receive(:delete_branch)
         expect(subject).to receive(:prompt).and_return(double(yes?: true))
         subject.new_branch('new_branch', 'main')
@@ -91,7 +91,7 @@ RSpec.describe Ninny::Git do
 
       it 'should exit if the user says no to recreation' do
         expect(subject).to receive(:`).with('git fetch --prune &> /dev/null')
-        expect(subject).to receive(:command).with('branch', ['--remote']).and_return('origin/new_branch')
+        expect(subject).to receive(:command).with('branch', '--remote').and_return('origin/new_branch')
         expect(subject).to receive(:exit)
         expect(subject).to receive(:prompt).and_return(double(yes?: false))
         subject.new_branch('new_branch', 'main')


### PR DESCRIPTION
<!--
Your audience for this merge request description is **code reviewers**. Help them understand the technical implications involved in this change. The JIRA ticket should outline the user-facing details.

Remember that Product and QA teams may have other test cases, verifications, and requirements associated with this change. Your Verification and QA plan should be directed towards Code Reviewers.
-->

## What and Why

Fixes ruby-git/ruby-git#662

The ninny gem calls an internal / private class in the [git gem](https://github.com/ruby-git/ruby-git) `Git::Lib`. Technically, it should limit its calls to the `Git::Base` object returned from `Git.open`.

In v1.14.0, a change was made to force calls to `Git::Lib#command` not to include arrays or nested arrays of args. This means that ([in this example from the ninny gem](https://github.com/dispatchitinc/ninny/blob/main/lib/ninny/git.rb#LL78C7-L78C65)):

```ruby
command('branch', ['-u', "origin/#{current_branch_name}"])
```

should be:

```ruby
command('branch', '-u', "origin/#{current_branch_name}")
```

This PR updates all the calls to `Ninny::Git#command` to not pass explicit arrays.

Since this gem is calling an internal class in the git gem, I'd consider this a stop gap measure.

While the tests pass, I was not able to test this with GitLab since I do not use GitLab. Since the tests completely mock out calls to the git gem, someone will need to run the code in this PR before merging it to make sure it works.